### PR TITLE
fix vote account identity selector

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -38,7 +38,7 @@ noVoting=$(ps aux | grep solana-validator | grep -c "\-\-no\-voting")
 if [ "$noVoting" -eq 0 ]; then
    if [ -z $identityPubkey ]; then identityPubkey=$($cli address --url $rpcURL); fi
    if [ -z $identityPubkey ]; then echo "auto-detection failed, please configure the identityPubkey in the script if not done"; exit 1; fi
-   if [ -z $voteAccount ]; then voteAccount=$($cli validators --url $rpcURL --output json-compact | jq -r '.validators[] | select(.identityPubkey == '\"$identityPubkey\"') | .voteAccountPubkey'); fi
+   if [ -z $voteAccount ]; then voteAccount=$($cli validators --url $rpcURL --output json-compact | jq -r 'first (.validators[] | select(.identityPubkey == '\"$identityPubkey\"')) | .voteAccountPubkey'); fi
    if [ -z $voteAccount ]; then echo "please configure the vote account in the script or wait for availability upon starting the node"; exit 1; fi
 fi
 


### PR DESCRIPTION
In case when someone, like me, has changed his vote account current selected returned two vote account ids
that produced an error

```
/home/solana/solanamonitoring/monitor.sh: line 42: [: 8dY5bV5Ur1Yf9Z21ETZBRNQCMFtTr8ZdByeTo8tNAxFW: binary operator expected
error: Found argument 'AD94FjYKbBs6e2yUPrmK79NWSLo5JsihiuFuvh8uj6jh' which wasn't expected, or isn't valid in this context
```


To prevent that I have changed query to get first vote account id
