### PR TITLE
fix solana price issue #14

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -44,7 +44,7 @@ fi
 
 validatorBalance=$($cli balance $identityPubkey | grep -o '[0-9.]*')
 validatorVoteBalance=$($cli balance $voteAccount | grep -o '[0-9.]*')
-solanaPrice=$(curl -s 'https://api.binance.com/api/v3/ticker/price?symbol=SOLUSDT' | jq -r .price)
+solanaPrice=$(curl -X 'GET' 'https://api.coingecko.com/api/v3/simple/price?ids=solana&vs_currencies=usd' -H 'accept: application/json' | jq -r .solana.usd)
 openfiles=$(cat /proc/sys/fs/file-nr | awk '{ print $1 }')
 validatorCheck=$($cli validators --url $rpcURL)
 


### PR DESCRIPTION
The Binance API now requires auth to retireve the SOLUSDT price. Coingecko is still publicly available. 

Response payload from Coingecko is structured like so:
``{"solana":{"usd":13.96}}``

This change uses the coingecko api and parses the output successfully. Confirmed working on my dashboard
[Juicy Stake dashboard](https://metrics.stakeconomy.com/d/f2b2HcaGz/solana-community-validator-dashboard?orgId=1&refresh=1m&var-pubkey=juigBT2qetpYpf1iwgjaiWTjryKkY3uUTVAnRFKkqY6&var-server=juicystake&var-inter=1m&var-netif=All)